### PR TITLE
Add PNP info to PCI attachment of aac, ncr, ath, aacraid drivers

### DIFF
--- a/sys/dev/aac/aac_pci.c
+++ b/sys/dev/aac/aac_pci.c
@@ -493,7 +493,7 @@ static driver_t aacch_driver = {
 
 static devclass_t	aacch_devclass;
 DRIVER_MODULE(aacch, pci, aacch_driver, aacch_devclass, NULL, NULL);
-MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, aacch,
+MODULE_PNP_INFO("U16:vendor;U16:device", pci, aacch,
     aac_identifiers, sizeof(aac_identifiers[0]), nitems(aac_identifiers) - 1);
 
 static int

--- a/sys/dev/aac/aac_pci.c
+++ b/sys/dev/aac/aac_pci.c
@@ -493,6 +493,8 @@ static driver_t aacch_driver = {
 
 static devclass_t	aacch_devclass;
 DRIVER_MODULE(aacch, pci, aacch_driver, aacch_devclass, NULL, NULL);
+MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#;D:#", pci, aac,
+    aac_identifiers, sizeof(aac_identifiers[0]), nitems(aac_identifiers) - 1);
 
 static int
 aacch_probe(device_t dev)

--- a/sys/dev/aac/aac_pci.c
+++ b/sys/dev/aac/aac_pci.c
@@ -493,7 +493,7 @@ static driver_t aacch_driver = {
 
 static devclass_t	aacch_devclass;
 DRIVER_MODULE(aacch, pci, aacch_driver, aacch_devclass, NULL, NULL);
-MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#;D:#", pci, aac,
+MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, aac,
     aac_identifiers, sizeof(aac_identifiers[0]), nitems(aac_identifiers) - 1);
 
 static int

--- a/sys/dev/aac/aac_pci.c
+++ b/sys/dev/aac/aac_pci.c
@@ -493,7 +493,7 @@ static driver_t aacch_driver = {
 
 static devclass_t	aacch_devclass;
 DRIVER_MODULE(aacch, pci, aacch_driver, aacch_devclass, NULL, NULL);
-MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, aac,
+MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, aacch,
     aac_identifiers, sizeof(aac_identifiers[0]), nitems(aac_identifiers) - 1);
 
 static int

--- a/sys/dev/aacraid/aacraid_pci.c
+++ b/sys/dev/aacraid/aacraid_pci.c
@@ -86,7 +86,7 @@ static driver_t aacraid_pci_driver = {
 static devclass_t	aacraid_devclass;
 
 DRIVER_MODULE(aacraid, pci, aacraid_pci_driver, aacraid_devclass, 0, 0);
-MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, aacraid,
+MODULE_PNP_INFO("U16:vendor;U16:device", pci, aacraid,
     aacraid_family_identifiers, sizeof(aacraid_family_identifiers[0]),
     nitems(aacraid_family_identifiers) - 1);		
 MODULE_DEPEND(aacraid, pci, 1, 1, 1);

--- a/sys/dev/aacraid/aacraid_pci.c
+++ b/sys/dev/aacraid/aacraid_pci.c
@@ -85,12 +85,6 @@ static driver_t aacraid_pci_driver = {
 
 static devclass_t	aacraid_devclass;
 
-DRIVER_MODULE(aacraid, pci, aacraid_pci_driver, aacraid_devclass, 0, 0);
-MODULE_PNP_INFO("U16:vendor;U16:device", pci, aacraid,
-    aacraid_family_identifiers, sizeof(aacraid_family_identifiers[0]),
-    nitems(aacraid_family_identifiers) - 1);		
-MODULE_DEPEND(aacraid, pci, 1, 1, 1);
-
 struct aac_ident
 {
 	u_int16_t		vendor;
@@ -109,6 +103,12 @@ struct aac_ident
 	 "Adaptec RAID Controller"},
 	{0, 0, 0, 0, 0, 0, 0}
 };
+
+DRIVER_MODULE(aacraid, pci, aacraid_pci_driver, aacraid_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device", pci, aacraid,
+    aacraid_family_identifiers, sizeof(aacraid_family_identifiers[0]),
+    nitems(aacraid_family_identifiers) - 1);		
+MODULE_DEPEND(aacraid, pci, 1, 1, 1);
 
 static struct aac_ident *
 aac_find_ident(device_t dev)

--- a/sys/dev/aacraid/aacraid_pci.c
+++ b/sys/dev/aacraid/aacraid_pci.c
@@ -86,6 +86,9 @@ static driver_t aacraid_pci_driver = {
 static devclass_t	aacraid_devclass;
 
 DRIVER_MODULE(aacraid, pci, aacraid_pci_driver, aacraid_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, aacraid,
+    aacraid_family_identifiers, sizeof(aacraid_family_identifiers[0]),
+    nitems(aacraid_family_identifiers) - 1);		
 MODULE_DEPEND(aacraid, pci, 1, 1, 1);
 
 struct aac_ident

--- a/sys/dev/ath/if_ath_pci.c
+++ b/sys/dev/ath/if_ath_pci.c
@@ -466,6 +466,8 @@ static driver_t ath_pci_driver = {
 };
 static	devclass_t ath_devclass;
 DRIVER_MODULE(if_ath_pci, pci, ath_pci_driver, ath_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, if_ath_pci,
+    ath_pci_id_table, sizeof(ath_pci_id_table), nitems(ath_pci_id_table) - 1);
 MODULE_VERSION(if_ath_pci, 1);
 MODULE_DEPEND(if_ath_pci, wlan, 1, 1, 1);		/* 802.11 media layer */
 MODULE_DEPEND(if_ath_pci, ath_main, 1, 1, 1);	/* if_ath driver */

--- a/sys/dev/ath/if_ath_pci.c
+++ b/sys/dev/ath/if_ath_pci.c
@@ -467,7 +467,7 @@ static driver_t ath_pci_driver = {
 static	devclass_t ath_devclass;
 DRIVER_MODULE(if_ath_pci, pci, ath_pci_driver, ath_devclass, 0, 0);
 MODULE_PNP_INFO("U16:vendor;U16:device;U16:#;U16:#", pci, if_ath_pci,
-    ath_pci_id_table, sizeof(ath_pci_id_table), nitems(ath_pci_id_table) - 1);
+    ath_pci_id_table, sizeof(ath_pci_id_table[0]), nitems(ath_pci_id_table) - 1);
 MODULE_VERSION(if_ath_pci, 1);
 MODULE_DEPEND(if_ath_pci, wlan, 1, 1, 1);		/* 802.11 media layer */
 MODULE_DEPEND(if_ath_pci, ath_main, 1, 1, 1);	/* if_ath driver */

--- a/sys/dev/ncr/ncr.c
+++ b/sys/dev/ncr/ncr.c
@@ -7109,7 +7109,7 @@ static devclass_t ncr_devclass;
 
 DRIVER_MODULE(ncr, pci, ncr_driver, ncr_devclass, 0, 0);
 MODULE_PNP_INFO("U32:device;U16:#;D:#", pci, ncr, ncr_chip_table,
-    sizeof(ncr_chip_table[0]), nitems(ncr_chip_table) - 1);
+    sizeof(ncr_chip_table[0]), nitems(ncr_chip_table));
 MODULE_DEPEND(ncr, cam, 1, 1, 1);
 MODULE_DEPEND(ncr, pci, 1, 1, 1);
 

--- a/sys/dev/ncr/ncr.c
+++ b/sys/dev/ncr/ncr.c
@@ -7108,6 +7108,8 @@ static driver_t ncr_driver = {
 static devclass_t ncr_devclass;
 
 DRIVER_MODULE(ncr, pci, ncr_driver, ncr_devclass, 0, 0);
+MODULE_PNP_INFO("U32:#;U16:#;D:#", pci, ncr, ncr_chip_table,
+    sizeof(ncr_chip_table[0]), nitems(ncr_chip_table) - 1);
 MODULE_DEPEND(ncr, cam, 1, 1, 1);
 MODULE_DEPEND(ncr, pci, 1, 1, 1);
 

--- a/sys/dev/ncr/ncr.c
+++ b/sys/dev/ncr/ncr.c
@@ -7108,7 +7108,7 @@ static driver_t ncr_driver = {
 static devclass_t ncr_devclass;
 
 DRIVER_MODULE(ncr, pci, ncr_driver, ncr_devclass, 0, 0);
-MODULE_PNP_INFO("U32:#;U16:#;D:#", pci, ncr, ncr_chip_table,
+MODULE_PNP_INFO("U32:device;U16:#;D:#", pci, ncr, ncr_chip_table,
     sizeof(ncr_chip_table[0]), nitems(ncr_chip_table) - 1);
 MODULE_DEPEND(ncr, cam, 1, 1, 1);
 MODULE_DEPEND(ncr, pci, 1, 1, 1);


### PR DESCRIPTION
The device id table for aac is 
```
static const struct aac_ident
{
	u_int16_t		vendor;
	u_int16_t		device;
	u_int16_t		subvendor;
	u_int16_t		subdevice;
	int			hwif;
	int			quirks;
	const char		*desc;
}
```
Therefore i used "U16:vendor;U16:device;U16:#;U16:#" as descriptor string in MODULE_PNP_INFO

The device id table for ncr is 
```
typedef struct {
	unsigned long	device_id;
	unsigned short	minrevid;
	char	       *name;
	unsigned char	maxburst;
	unsigned char	maxoffs;
	unsigned char	clock_divn;
	unsigned int	features;
} ncr_chip;
```
unsigned long is atleast 32 bit long (hardware dependent)
unsigned short is atleast 16 bit long (hardware dependent)
Therefore i used "U32:device;U16:#;D:#" as descriptor string in MODULE_PNP_INFO

The device id table for ath is 
```
struct pci_device_id {
	int vendor_id;
	int device_id;
	int sub_vendor_id;
	int sub_device_id;
	int driver_data;
	int match_populated:1;
	int match_vendor_id:1;
	int match_device_id:1;
	int match_sub_vendor_id:1;
	int match_sub_device_id:1;
};
```
Therefore i used "U16:vendor;U16:device;U16:#;U16:#" as descriptor string in MODULE_PNP_INFO

The device id table for aacraid is
```
struct aac_ident
{
	u_int16_t		vendor;
	u_int16_t		device;
	u_int16_t		subvendor;
	u_int16_t		subdevice;
	int			hwif;
	int			quirks;
	char			*desc;
}
```
Therefore i used "U16:vendor;U16:device;U16:#;U16:#" as descriptor string in MODULE_PNP_INFO