### PR TITLE
Add PNP info to PCI attachment of ae, age, ahci, amr, ale, an, bwi, bwn drivers

### DIFF
--- a/sys/dev/ae/if_ae.c
+++ b/sys/dev/ae/if_ae.c
@@ -177,6 +177,8 @@ static driver_t ae_driver = {
 static devclass_t ae_devclass;
 
 DRIVER_MODULE(ae, pci, ae_driver, ae_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;D:#", pci, ae, ae_devs,
+    sizeof(ae_devs[0]), nitems(ae_devs));
 DRIVER_MODULE(miibus, ae, miibus_driver, miibus_devclass, 0, 0);
 MODULE_DEPEND(ae, pci, 1, 1, 1);
 MODULE_DEPEND(ae, ether, 1, 1, 1);


### PR DESCRIPTION
The device id table for ahci is
```
static const struct {
	uint32_t	id;
	uint8_t		rev;
	const char	*name;
	int		quirks;
} ahci_ids[]
```
Therefore i used "W32:vendor/device" as descriptor string in MODULE_PNP_INFO

The device id table for an is
```
struct an_type {
	u_int16_t		an_vid;
	u_int16_t		an_did;
	char			*an_name;
};
```
Therefore i used "U16:vendor;U16:device;D:#" as descriptor string in MODULE_PNP_INFO

The device id table for bwn is
```
struct bwn_pci_device {
	uint16_t	vendor;
	uint16_t	device;
	const char	*desc;
	uint32_t	quirks;
}
```
Therefore i used "U16:vendor;U16:device;D:#" as descriptor string in MODULE_PNP_INFO

The device id table for bwi is
```
static const struct bwi_dev {
	uint16_t	vid;
	uint16_t	did;
	const char	*desc;
}
```
Therefore i used "U16:vendor;U16:device;D:#" as descriptor string in MODULE_PNP_INFO

The device id table for ale is
```
static const struct ale_dev {
	uint16_t	ale_vendorid;
	uint16_t	ale_deviceid;
	const char	*ale_name;
}
```
Therefore i used "U16:vendor;U16:device;D:#" as descriptor string in MODULE_PNP_INFO

The device id table for amr is
```
static struct amr_ident
{
    int		vendor;
    int		device;
    int		flags;
#define AMR_ID_PROBE_SIG	(1<<0)	/* generic i960RD, check signature */
#define AMR_ID_DO_SG64		(1<<1)
#define AMR_ID_QUARTZ		(1<<2)
}
```
Therefore i used "U16:vendor;U16:device" as descriptor string in MODULE_PNP_INFO

The device id table for age is
```
static struct age_dev {
	uint16_t	age_vendorid;
	uint16_t	age_deviceid;
	const char	*age_name;
} age_devs[];
```
Therefore i used "U16:vendor;U16:device;D:#" as descriptor string in MODULE_PNP_INFO

The device id table for ae is
```
static struct ae_dev {
	uint16_t	vendorid;
	uint16_t	deviceid;
	const char	*name;
} ae_devs[];
```
Therefore i used "U16:vendor;U16:device;D:#" as descriptor string in MODULE_PNP_INFO


