### PR TITLE
Add PNP info to PCI attachment of arcmsr, bt, cbb, de, ebus, emujoy, fixup_pci, hifn, hptiop, imcsmb, snd_emu10k1 (emu_pci) drivers

### DIFF
--- a/sys/dev/arcmsr/arcmsr.c
+++ b/sys/dev/arcmsr/arcmsr.c
@@ -213,6 +213,96 @@ static d_open_t	arcmsr_open;
 static d_close_t arcmsr_close;
 static d_ioctl_t arcmsr_ioctl;
 
+static struct arcmsr_dev {
+	uint16_t vendorid;
+	uint32_t deviceid;
+	uint16_t subdeviceid;
+	char *description;
+} arcmsr_devs[] = {
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1110, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1200, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1201, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1210, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1120, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1130, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1160, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1170, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1220, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1230, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1231, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1260, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1261, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1270, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1280, 0,
+	    "Areca SATA 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1212, 0,
+	    "Areca SAS 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1222, 0,
+	    "Areca SAS 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1380, 0,
+	    "Areca SAS 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1381, 0,
+	    "Areca SAS 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1680, 0,
+	    "Areca SAS 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1681, 0,
+	    "Areca SAS 3G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1880, 0,
+	    "Areca SAS 6G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1882, 0,
+	    "Areca SAS 6G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1213, 0,
+	    "Areca SAS 6G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1223, 0,
+	    "Areca SAS 6G Host Adapter RAID Controller\n(RAID6 capable)"},
+        {PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1880, ARECA_SUB_DEV_ID_1883,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1882, ARECA_SUB_DEV_ID_1883,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1213, ARECA_SUB_DEV_ID_1883,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1223, ARECA_SUB_DEV_ID_1883,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1880, ARECA_SUB_DEV_ID_1216,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1882, ARECA_SUB_DEV_ID_1216,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1213, ARECA_SUB_DEV_ID_1216,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1223, ARECA_SUB_DEV_ID_1216,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+        {PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1880, ARECA_SUB_DEV_ID_1226,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1882, ARECA_SUB_DEV_ID_1226,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1213, ARECA_SUB_DEV_ID_1226,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1223, ARECA_SUB_DEV_ID_1226,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1884, 0,
+	    "Areca SAS 12G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1214, 0,
+	    "Areca SATA 6G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{PCI_VENDOR_ID_ARECA, PCIDevVenIDARC1203, 0,
+	    "Areca SATA 6G Host Adapter RAID Controller\n(RAID6 capable)"},
+	{0, 0, 0, 0},
+};
+
+
 static device_method_t arcmsr_methods[]={
 	DEVMETHOD(device_probe,		arcmsr_probe),
 	DEVMETHOD(device_attach,	arcmsr_attach),
@@ -234,6 +324,8 @@ static driver_t arcmsr_driver={
 
 static devclass_t arcmsr_devclass;
 DRIVER_MODULE(arcmsr, pci, arcmsr_driver, arcmsr_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;W32:vendor/device;U16:subdevice;D:#", pci, arcmsr,
+    arcmsr_devs, sizeof(arcmsr_devs[0]), nitems(arcmsr_devs) - 1);
 MODULE_DEPEND(arcmsr, pci, 1, 1, 1);
 MODULE_DEPEND(arcmsr, cam, 1, 1, 1);
 #ifndef BUS_DMA_COHERENT		
@@ -4908,74 +5000,28 @@ initialize_failed:
 */
 static int arcmsr_probe(device_t dev)
 {
-	u_int32_t id;
+	const struct arcmsr_dev *arcd;
+	u_int32_t did;
+	size_t i;
 	u_int16_t sub_device_id;
-	static char buf[256];
-	char x_type[]={"unknown"};
-	char *type;
-	int raid6 = 1;
+	char buf[256];
 
 	if (pci_get_vendor(dev) != PCI_VENDOR_ID_ARECA) {
 		return (ENXIO);
 	}
+	did = pci_get_devid(dev);
 	sub_device_id = pci_read_config(dev, PCIR_SUBDEV_0, 2);
-	switch(id = pci_get_devid(dev)) {
-	case PCIDevVenIDARC1110:
-	case PCIDevVenIDARC1200:
-	case PCIDevVenIDARC1201:
-	case PCIDevVenIDARC1210:
-		raid6 = 0;
-		/*FALLTHRU*/
-	case PCIDevVenIDARC1120:
-	case PCIDevVenIDARC1130:
-	case PCIDevVenIDARC1160:
-	case PCIDevVenIDARC1170:
-	case PCIDevVenIDARC1220:
-	case PCIDevVenIDARC1230:
-	case PCIDevVenIDARC1231:
-	case PCIDevVenIDARC1260:
-	case PCIDevVenIDARC1261:
-	case PCIDevVenIDARC1270:
-	case PCIDevVenIDARC1280:
-		type = "SATA 3G";
-		break;
-	case PCIDevVenIDARC1212:
-	case PCIDevVenIDARC1222:
-	case PCIDevVenIDARC1380:
-	case PCIDevVenIDARC1381:
-	case PCIDevVenIDARC1680:
-	case PCIDevVenIDARC1681:
-		type = "SAS 3G";
-		break;
-	case PCIDevVenIDARC1880:
-	case PCIDevVenIDARC1882:
-	case PCIDevVenIDARC1213:
-	case PCIDevVenIDARC1223:
-		if ((sub_device_id == ARECA_SUB_DEV_ID_1883) ||
-		    (sub_device_id == ARECA_SUB_DEV_ID_1216) ||
-		    (sub_device_id == ARECA_SUB_DEV_ID_1226))
-			type = "SAS 12G";
-		else
-			type = "SAS 6G";
-		break;
-	case PCIDevVenIDARC1884:
-		type = "SAS 12G";
-		break;
-	case PCIDevVenIDARC1214:
-	case PCIDevVenIDARC1203:
-		type = "SATA 6G";
-		break;
-	default:
-		type = x_type;
-		raid6 = 0;
-		break;
+	for (i = 0; i < nitems(arcmsr_devs); i++) {
+		arcd = &arcmsr_devs[i];
+		if ((arcd->deviceid == did) &&
+		    ((arcd->subdeviceid == sub_device_id)
+		     || (arcd->subdeviceid == 0))) {
+			sprintf(buf, "%s\n%s\n", arcd->description, ARCMSR_DRIVER_VERSION);
+			device_set_desc_copy(dev, buf);
+			return (BUS_PROBE_DEFAULT);
+		}
 	}
-	if(type == x_type)
-		return(ENXIO);
-	sprintf(buf, "Areca %s Host Adapter RAID Controller %s\n%s\n",
-		type, raid6 ? "(RAID6 capable)" : "", ARCMSR_DRIVER_VERSION);
-	device_set_desc_copy(dev, buf);
-	return (BUS_PROBE_DEFAULT);
+	return(ENXIO);
 }
 /*
 ************************************************************************

--- a/sys/dev/imcsmb/imcsmb_pci.c
+++ b/sys/dev/imcsmb/imcsmb_pci.c
@@ -129,22 +129,23 @@ static struct imcsmb_reg_set imcsmb_regs[] = {
 };
 
 static struct imcsmb_pci_device {
-	uint16_t	id;
+	uint16_t   vendorid;
+	uint16_t   deviceid;
 	char		*name;
 } imcsmb_pci_devices[] = {
-	{IMCSMB_PCI_DEV_ID_IMC0_SBX,
+	{PCI_VENDOR_INTEL, IMCSMB_PCI_DEV_ID_IMC0_SBX,
 	    "Intel Sandybridge Xeon iMC 0 SMBus controllers"	},
-	{IMCSMB_PCI_DEV_ID_IMC0_IBX,
+	{PCI_VENDOR_INTEL, IMCSMB_PCI_DEV_ID_IMC0_IBX,
 	    "Intel Ivybridge Xeon iMC 0 SMBus controllers"	},
-	{IMCSMB_PCI_DEV_ID_IMC0_HSX,
+	{PCI_VENDOR_INTEL, IMCSMB_PCI_DEV_ID_IMC0_HSX,
 	    "Intel Haswell Xeon iMC 0 SMBus controllers"	},
-	{IMCSMB_PCI_DEV_ID_IMC1_HSX,
+	{PCI_VENDOR_INTEL, IMCSMB_PCI_DEV_ID_IMC1_HSX,
 	    "Intel Haswell Xeon iMC 1 SMBus controllers"	},
-	{IMCSMB_PCI_DEV_ID_IMC0_BDX,
+	{PCI_VENDOR_INTEL, IMCSMB_PCI_DEV_ID_IMC0_BDX,
 	    "Intel Broadwell Xeon iMC 0 SMBus controllers"	},
-	{IMCSMB_PCI_DEV_ID_IMC1_BDX,
+	{PCI_VENDOR_INTEL, IMCSMB_PCI_DEV_ID_IMC1_BDX,
 	    "Intel Broadwell Xeon iMC 1 SMBus controllers"	},
-	{0, NULL},
+	{0, 0, NULL},
 };
 
 /* Device methods. */
@@ -247,9 +248,9 @@ imcsmb_pci_probe(device_t dev)
 
 	pci_dev_id = pci_get_device(dev);
 	for (pci_device = imcsmb_pci_devices;
-	    pci_device->name != NULL;
-	    pci_device++) {
-		if (pci_dev_id == pci_device->id) {
+	  pci_device->name != NULL;
+	  pci_device++) {
+		if (pci_dev_id == pci_device->deviceid) {
 			device_set_desc(dev, pci_device->name);
 			rc = BUS_PROBE_DEFAULT;
 			goto out;
@@ -339,6 +340,8 @@ static driver_t imcsmb_pci_driver = {
 };
 
 DRIVER_MODULE(imcsmb_pci, pci, imcsmb_pci_driver, imcsmb_pci_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;D:#", pci, imcsmb_pci, imcsmb_pci_devices,
+    sizeof(imcsmb_pci_devices[0]), nitems(imcsmb_pci_devices) - 1);
 MODULE_DEPEND(imcsmb_pci, pci, 1, 1, 1);
 MODULE_VERSION(imcsmb_pci, 1);
 

--- a/sys/dev/pccbb/pccbb_pci.c
+++ b/sys/dev/pccbb/pccbb_pci.c
@@ -983,4 +983,6 @@ static driver_t cbb_driver = {
 };
 
 DRIVER_MODULE(cbb, pci, cbb_driver, cbb_devclass, 0, 0);
+MODULE_PNP_INFO("W32:vendor/device;D:#", pci, cbb, yc_chipsets,
+    sizeof(yc_chipsets[0]), nitems(yc_chipsets) - 1);
 MODULE_DEPEND(cbb, exca, 1, 1, 1);

--- a/sys/dev/pci/fixup_pci.c
+++ b/sys/dev/pci/fixup_pci.c
@@ -55,6 +55,15 @@ static int	fixup_pci_probe(device_t dev);
 static void	fixwsc_natoma(device_t dev);
 static void	fixc1_nforce2(device_t dev);
 
+static struct fixup_pci_dev {
+	uint32_t devid;
+	const char *description;
+} fixup_pci_devs[] = {
+	{0x12378086, "Intel 82440FX (Natoma)"},
+	{0x01e010de, "nVidia nForce2"},
+	{0, 0},
+};
+
 static device_method_t fixup_pci_methods[] = {
     /* Device interface */
     DEVMETHOD(device_probe,		fixup_pci_probe),
@@ -71,19 +80,24 @@ static driver_t fixup_pci_driver = {
 static devclass_t fixup_pci_devclass;
 
 DRIVER_MODULE(fixup_pci, pci, fixup_pci_driver, fixup_pci_devclass, 0, 0);
+MODULE_PNP_INFO("W32:vendor/device;D:#", pci, fixup_pci, fixup_pci_devs,
+    sizeof(fixup_pci_devs[0]), nitems(fixup_pci_devs) - 1);
 
 static int
 fixup_pci_probe(device_t dev)
 {
-    switch (pci_get_devid(dev)) {
-    case 0x12378086:		/* Intel 82440FX (Natoma) */
-	fixwsc_natoma(dev);
-	break;
-    case 0x01e010de:		/* nVidia nForce2 */
-	fixc1_nforce2(dev);
-	break;
-    }
-    return(ENXIO);
+	const struct fixup_pci_dev *fixd;
+	uint32_t devid;
+	size_t i;
+
+	devid = pci_get_devid(dev);
+	for (i = 0; i < nitems(fixup_pci_devs); i++) {
+		fixd = &fixup_pci_devs[i];
+		if(fixd->devid == devid) {
+			fixwsc_natoma(dev);
+		}
+	}
+	return(ENXIO);
 }
 
 static void


### PR DESCRIPTION
The device id table for hptiop is
```
static struct hptiop_dev {
	uint16_t vendorid;
	uint16_t deviceid;
	const char *description;
	struct hptiop_adapter_ops *ops;
} hptiop_devs[]
```
Therefore i used "U16:vendor;U16:device" as description string in PNP_INFO

The device id table for arcmsr is
```
static struct arcmsr_dev {
	uint16_t vendorid;
	uint32_t deviceid;
	uint16_t subdeviceid;
	char *description;
} arcmsr_devs[]
```
Therefore i used "U16:vendor;U32:device;U16:subdevice" as description string in PNP_INFO

The device table of hifn is
```
static struct hifn_dev {
        uint16_t vendorid;
        uint16_t deviceid;
} hifn_devs[]
```
Therefore i used "U16:vendor;U16:device" as description string in PNP_INFO 

The device id table of bt driver is
```
static struct bt_dev {
        uint16_t vendorid;
	uint32_t deviceid;
	const char *description;
} bt_devs[]
```
Therefore i used "U16:vendor;U32:device" as description string in PNP_INFO 

The device id table of snd_emu10k1 (emu_pci)
```
static struct emu_pci_dev {
	uint16_t vendorid;
	uint32_t deviceid;
	uint8_t rev;
	const char *description;
} emu_pci_devs[]
```
Therefore i used "U16:vendor;U32:device" as description string in PNP_INFO 

The device id table for emujoy driver is
```
static struct emujoy_pci_dev {
	uint16_t vendorid;
	uint32_t deviceid;
	const char *description;
} emujoy_pci_devs[]
```
Therefore i used "U16:vendor;U32:device" as description string in PNP_INFO 

The device table of ebus is
```
static struct ebus_pci_dev {
	uint16_t vendorid;
	uint16_t deviceid;
	const char *description;
} ebus_pci_devs[]
```
Therefore i used "U16:vendor;U16:device" as description string in PNP_INFO

The device id table for cbb driver is
```
static struct yenta_chipinfo {
	uint32_t yc_id;
	const	char *yc_name;
	int	yc_chiptype;
} yc_chipsets[]
```
Therefore i used "W32:vendor/device" as the description string in PNP_INFO
The device id table for de driver is
```
static struct de_dev {
	uint16_t vendorid;
	uint16_t deviceid;
	uint8_t revid;
	const char *description;
}
```
Therefore i used "U16:vendor;U16:device" as description string in PNP_INFO

The device id table for fixup_pci driver is
```
static struct fixup_pci_dev {
	uint32_t devid;
	const char *description;
} fixup_pci_devs[]
```
Therefore i used "W32:vendor/device" as the description string in PNP_INFO

The device id table for imcsmb driver is
```
static struct imcsmb_pci_device {
	uint16_t	vendorid;
        uint16_t	deviceid;
	char		*name;
} imcsmb_pci_devices[]
```
Therefore i used "U16:vendor;U16:device" as the description string in PNP_INFO