### PR TITLE
Add PNP info to PCI attachment of et, iir, ignore, ips, ipw, isab, ismt, iwm, ix, ixgb, ixv driver

### DIFF
--- a/sys/dev/et/if_et.c
+++ b/sys/dev/et/if_et.c
@@ -188,6 +188,8 @@ static driver_t et_driver = {
 static devclass_t et_devclass;
 
 DRIVER_MODULE(et, pci, et_driver, et_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;D:#", pci, et, et_devices,
+    sizeof(et_devices[0]), nitems(et_devices) - 1);
 DRIVER_MODULE(miibus, et, miibus_driver, miibus_devclass, 0, 0);
 
 static int	et_rx_intr_npkts = 32;

--- a/sys/dev/iir/iir_pci.c
+++ b/sys/dev/iir/iir_pci.c
@@ -141,6 +141,16 @@ void            gdt_mpr_release_event(struct gdt_softc *);
 void            gdt_mpr_set_sema0(struct gdt_softc *);
 int             gdt_mpr_test_busy(struct gdt_softc *);
 
+static struct iir_pci_dev {
+	uint16_t vendorid;
+	uint16_t deviceid;
+	const char *description;
+} iir_pci_devs[] = {
+	{INTEL_VENDOR_ID_IIR, INTEL_DEVICE_ID_IIR, "Intel Integrated RAID Controller"},
+	{GDT_VENDOR_ID, GDT_DEVICE_ID_NEWRX, "ICP Disk Array Controller"},
+	{0, 0, NULL},
+};
+
 static device_method_t iir_pci_methods[] = {
         /* Device interface */
         DEVMETHOD(device_probe,         iir_pci_probe),
@@ -159,23 +169,36 @@ static  driver_t iir_pci_driver =
 static devclass_t iir_devclass;
 
 DRIVER_MODULE(iir, pci, iir_pci_driver, iir_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;D:#", pci, iir, iir_pci_devs,
+    sizeof(iir_pci_devs[0]), nitems(iir_pci_devs) - 1);
 MODULE_DEPEND(iir, pci, 1, 1, 1);
 MODULE_DEPEND(iir, cam, 1, 1, 1);
 
 static int
 iir_pci_probe(device_t dev)
 {
-    if (pci_get_vendor(dev) == INTEL_VENDOR_ID_IIR &&
-        pci_get_device(dev) == INTEL_DEVICE_ID_IIR) {
-        device_set_desc(dev, "Intel Integrated RAID Controller");
-        return (BUS_PROBE_DEFAULT);
+    const struct iir_pci_dev *iird;
+    uint16_t did;
+    uint16_t vid;
+    size_t i;
+
+    vid = pci_get_vendor(dev);
+    did = pci_get_device(dev);
+    if (vid == GDT_VENDOR_ID && 
+	(did >= GDT_DEVICE_ID_MIN &&
+	did <= GDT_DEVICE_ID_MAX)) {
+	    device_set_desc(dev, "ICP Disk Array Controller");
+	    return (BUS_PROBE_DEFAULT);
     }
-    if (pci_get_vendor(dev) == GDT_VENDOR_ID &&
-        ((pci_get_device(dev) >= GDT_DEVICE_ID_MIN &&
-        pci_get_device(dev) <= GDT_DEVICE_ID_MAX) ||
-        pci_get_device(dev) == GDT_DEVICE_ID_NEWRX)) {
-        device_set_desc(dev, "ICP Disk Array Controller");
-        return (BUS_PROBE_DEFAULT);
+    else {
+	    for (i = 0; i < nitems(iir_pci_devs) - 1; i++) {
+		    iird = &iir_pci_devs[i];
+		    if (vid == iird->vendorid &&
+			did == iird->deviceid) {
+			    device_set_desc(dev, iird->description);
+			    return (BUS_PROBE_DEFAULT);
+		    }
+	    }
     }
     return (ENXIO);
 }

--- a/sys/dev/ips/ips_pci.c
+++ b/sys/dev/ips/ips_pci.c
@@ -40,23 +40,34 @@ __FBSDID("$FreeBSD$");
 static int ips_pci_free(ips_softc_t *sc);
 static void ips_intrhook(void *arg);
 
+static struct ips_pci_dev {
+	uint16_t vendorid;
+	uint16_t deviceid;
+	const char *description;
+} ips_pci_devs[] = {
+	{IPS_VENDOR_ID, IPS_MORPHEUS_DEVICE_ID, "IBM ServeRAID Adapter"},
+	{IPS_VENDOR_ID, IPS_COPPERHEAD_DEVICE_ID, "IBM ServeRAID Adapter"},
+	{IPS_VENDOR_ID_ADAPTEC, IPS_MARCO_DEVICE_ID, "Adaptec ServeRAID Adapter"},
+	{0,0,0},
+};
+
 static int ips_pci_probe(device_t dev)
 {
+        const struct ips_pci_dev *ipsd;
+	u_int16_t vid;
+	u_int16_t did;
+	size_t i;
 
-        if ((pci_get_vendor(dev) == IPS_VENDOR_ID) &&
-	    (pci_get_device(dev) == IPS_MORPHEUS_DEVICE_ID)) {
-		device_set_desc(dev, "IBM ServeRAID Adapter");
-                return (BUS_PROBE_DEFAULT);
-        } else if ((pci_get_vendor(dev) == IPS_VENDOR_ID) &&
-	    (pci_get_device(dev) == IPS_COPPERHEAD_DEVICE_ID)) {
-		device_set_desc(dev, "IBM ServeRAID Adapter");
-		return (BUS_PROBE_DEFAULT);
-        } else if ((pci_get_vendor(dev) == IPS_VENDOR_ID_ADAPTEC) &&
-	    (pci_get_device(dev) == IPS_MARCO_DEVICE_ID)) {
-		device_set_desc(dev, "Adaptec ServeRAID Adapter");
-		return (BUS_PROBE_DEFAULT);
+	vid = pci_get_vendor(dev);
+	did = pci_get_device(dev);
+	for (i = 0; i < nitems(ips_pci_devs) - 1; i++) {
+		ipsd = &ips_pci_devs[i];
+		if ((vid == ipsd->vendorid) && (did == ipsd->deviceid)) {
+			device_set_desc(dev, ipsd->description);
+			return (BUS_PROBE_DEFAULT);
+		}
 	}
-        return(ENXIO);
+	return (ENXIO);
 }
 
 static int ips_pci_attach(device_t dev)
@@ -221,3 +232,5 @@ static driver_t ips_pci_driver = {
 
 static devclass_t ips_devclass;
 DRIVER_MODULE(ips, pci, ips_pci_driver, ips_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;D:#", pci, ips, ips_pci_devs,
+    sizeof(ips_pci_devs[0]), nitems(ips_pci_devs) - 1);

--- a/sys/dev/ipw/if_ipw.c
+++ b/sys/dev/ipw/if_ipw.c
@@ -202,6 +202,8 @@ static driver_t ipw_driver = {
 static devclass_t ipw_devclass;
 
 DRIVER_MODULE(ipw, pci, ipw_driver, ipw_devclass, NULL, NULL);
+MODULE_PNP_INFO("U16:vendor;U16:device;D:#", pci, ipw, ipw_ident_table,
+    sizeof(ipw_ident_table[0]), nitems(ipw_ident_table) - 1);
 
 MODULE_VERSION(ipw, 1);
 

--- a/sys/dev/ismt/ismt.c
+++ b/sys/dev/ismt/ismt.c
@@ -718,27 +718,32 @@ fail:
 #define ID_INTEL_S1200_SMT1		0x0c5a8086
 #define ID_INTEL_C2000_SMT		0x1f158086
 
+static struct ismt_dev {
+	uint32_t devid;
+	const char *description;
+} ismt_devs[] = {
+	{ID_INTEL_S1200_SMT0, "Atom Processor S1200 SMBus 2.0 Controller 0"},
+	{ID_INTEL_S1200_SMT1, "Atom Processor S1200 SMBus 2.0 Controller 1"},
+	{ID_INTEL_C2000_SMT, "Atom Processor C2000 SMBus 2.0"},
+	{0, NULL},
+};
+
 static int
 ismt_probe(device_t dev)
 {
-	const char *desc;
+	uint32_t did;
+        size_t i;
 
-	switch (pci_get_devid(dev)) {
-	case ID_INTEL_S1200_SMT0:
-		desc = "Atom Processor S1200 SMBus 2.0 Controller 0";
-		break;
-	case ID_INTEL_S1200_SMT1:
-		desc = "Atom Processor S1200 SMBus 2.0 Controller 1";
-		break;
-	case ID_INTEL_C2000_SMT:
-		desc = "Atom Processor C2000 SMBus 2.0";
-		break;
-	default:
-		return (ENXIO);
+	did = pci_get_devid(dev);
+	const struct ismt_dev *ismtd;
+	for (i = 0; i < nitems(ismt_devs) - 1; i++) {
+		ismtd = &ismt_devs[i];
+		if (did == ismtd->devid) {
+			device_set_desc(dev, ismtd->description);
+			return (BUS_PROBE_DEFAULT);
+		}
 	}
-
-	device_set_desc(dev, desc);
-	return (BUS_PROBE_DEFAULT);
+	return (ENXIO);
 }
 
 /* Device methods */
@@ -771,6 +776,8 @@ static driver_t ismt_pci_driver = {
 static devclass_t ismt_pci_devclass;
 
 DRIVER_MODULE(ismt, pci, ismt_pci_driver, ismt_pci_devclass, 0, 0);
+MODULE_PNP_INFO("W32:vendor/device;D:#", pci, ismt, ismt_devs,
+    sizeof(ismt_devs[0]), nitems(ismt_devs) - 1);
 DRIVER_MODULE(smbus, ismt, smbus_driver, smbus_devclass, 0, 0);
 
 MODULE_DEPEND(ismt, pci, 1, 1, 1);

--- a/sys/dev/iwm/if_iwm.c
+++ b/sys/dev/iwm/if_iwm.c
@@ -5694,21 +5694,23 @@ iwm_intr(void *arg)
 #define	PCI_PRODUCT_INTEL_WL_8265_1	0x24fd
 
 static const struct iwm_devices {
+	uint16_t                vendor;
 	uint16_t		device;
 	const struct iwm_cfg	*cfg;
 } iwm_devices[] = {
-	{ PCI_PRODUCT_INTEL_WL_3160_1, &iwm3160_cfg },
-	{ PCI_PRODUCT_INTEL_WL_3160_2, &iwm3160_cfg },
-	{ PCI_PRODUCT_INTEL_WL_3165_1, &iwm3165_cfg },
-	{ PCI_PRODUCT_INTEL_WL_3165_2, &iwm3165_cfg },
-	{ PCI_PRODUCT_INTEL_WL_3168_1, &iwm3168_cfg },
-	{ PCI_PRODUCT_INTEL_WL_7260_1, &iwm7260_cfg },
-	{ PCI_PRODUCT_INTEL_WL_7260_2, &iwm7260_cfg },
-	{ PCI_PRODUCT_INTEL_WL_7265_1, &iwm7265_cfg },
-	{ PCI_PRODUCT_INTEL_WL_7265_2, &iwm7265_cfg },
-	{ PCI_PRODUCT_INTEL_WL_8260_1, &iwm8260_cfg },
-	{ PCI_PRODUCT_INTEL_WL_8260_2, &iwm8260_cfg },
-	{ PCI_PRODUCT_INTEL_WL_8265_1, &iwm8265_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_3160_1, &iwm3160_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_3160_2, &iwm3160_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_3165_1, &iwm3165_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_3165_2, &iwm3165_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_3168_1, &iwm3168_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_7260_1, &iwm7260_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_7260_2, &iwm7260_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_7265_1, &iwm7265_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_7265_2, &iwm7265_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_8260_1, &iwm8260_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_8260_2, &iwm8260_cfg },
+	{PCI_VENDOR_INTEL, PCI_PRODUCT_INTEL_WL_8265_1, &iwm8265_cfg },
+	{0, 0, NULL},
 };
 
 static int
@@ -6460,6 +6462,8 @@ static driver_t iwm_pci_driver = {
 static devclass_t iwm_devclass;
 
 DRIVER_MODULE(iwm, pci, iwm_pci_driver, iwm_devclass, NULL, NULL);
+MODULE_PNP_INFO("U16:vendor;U16:device", pci, iwm, iwm_devices,
+    sizeof(iwm_devices[0]), nitems(iwm_devices) - 1);
 MODULE_DEPEND(iwm, firmware, 1, 1, 1);
 MODULE_DEPEND(iwm, pci, 1, 1, 1);
 MODULE_DEPEND(iwm, wlan, 1, 1, 1);

--- a/sys/dev/ixgb/if_ixgb.c
+++ b/sys/dev/ixgb/if_ixgb.c
@@ -171,6 +171,9 @@ static driver_t ixgb_driver = {
 
 static devclass_t ixgb_devclass;
 DRIVER_MODULE(ixgb, pci, ixgb_driver, ixgb_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device;U16:subvendor;U16:subdevice",
+    pci, ixgb, ixgb_vendor_info_array, sizeof(ixgb_vendor_info_array[0]),
+        nitems(ixgb_vendor_info_array) - 1);
 
 MODULE_DEPEND(ixgb, pci, 1, 1, 1);
 MODULE_DEPEND(ixgb, ether, 1, 1, 1);

--- a/sys/dev/ixgbe/if_ix.c
+++ b/sys/dev/ixgbe/if_ix.c
@@ -237,6 +237,8 @@ static driver_t ix_driver = {
 
 devclass_t ix_devclass;
 DRIVER_MODULE(ix, pci, ix_driver, ix_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device", pci, ix, ixgbe_vendor_info_array,
+    sizeof(ixgbe_vendor_info_array[0]), nitems(ixgbe_vendor_info_array) - 1);
 
 MODULE_DEPEND(ix, pci, 1, 1, 1);
 MODULE_DEPEND(ix, ether, 1, 1, 1);

--- a/sys/dev/ixgbe/if_ixv.c
+++ b/sys/dev/ixgbe/if_ixv.c
@@ -143,6 +143,8 @@ static driver_t ixv_driver = {
 
 devclass_t ixv_devclass;
 DRIVER_MODULE(ixv, pci, ixv_driver, ixv_devclass, 0, 0);
+MODULE_PNP_INFO("U16:vendor;U16:device", pci, ixv, ixv_vendor_info_array,
+    sizeof(ixv_vendor_info_array[0]), nitems(ixv_vendor_info_array) - 1);
 MODULE_DEPEND(ixv, pci, 1, 1, 1);
 MODULE_DEPEND(ixv, ether, 1, 1, 1);
 #ifdef DEV_NETMAP

--- a/sys/dev/pci/ignore_pci.c
+++ b/sys/dev/pci/ignore_pci.c
@@ -43,6 +43,13 @@ __FBSDID("$FreeBSD$");
 #include <dev/pci/pcivar.h>
 
 static int	ignore_pci_probe(device_t dev);
+static struct ignore_pci_dev {
+	uint32_t devid;
+	const char *description;
+} ignore_pci_devs[] = {
+	{0x10001042, "ignored"},
+	{0, 0},
+};
 
 static device_method_t ignore_pci_methods[] = {
     /* Device interface */
@@ -60,6 +67,8 @@ static driver_t ignore_pci_driver = {
 static devclass_t ignore_pci_devclass;
 
 DRIVER_MODULE(ignore_pci, pci, ignore_pci_driver, ignore_pci_devclass, 0, 0);
+MODULE_PNP_INFO("U32:vendor/device", pci, ignore_pci, ignore_pci_devs,
+    sizeof(ignore_pci_devs[0]), nitems(ignore_pci_devs) - 1);
 
 static int
 ignore_pci_probe(device_t dev)


### PR DESCRIPTION
The device id table for isab driver is
```
static struct isab_pci_dev {
	uint32_t devid;
	const char *description;
} isab_pci_devs[]
```
Therefore i used "U32:vendor/device" in descriptor string.

The device id table for ignore driver is
```
static struct ignore_pci_dev {
	uint32_t devid;
	const char *descriptiption;
} ignore_pci_devs[]
```
Therefore i used "U32:vendor/device" in descriptor string.

The device id table of iir driver is
```
static struct iir_pci_dev {
	uint16_t vendorid;
	uint16_t deviceid;
	const char *description;
} iir_pci_devs[]
```
Therefore i used "U16:vendor;U16:device" in descriptor string.