### PR TITLE
Add PNP info to PCI attachments of PCIBIOS, PCIB, QLA, QLA80XX, QL, PIIX, RP, OCE, RE, PPC driver

### DIFF
--- a/sys/dev/oce/oce_if.c
+++ b/sys/dev/oce/oce_if.c
@@ -214,12 +214,6 @@ static driver_t oce_driver = {
 static devclass_t oce_devclass;
 
 
-DRIVER_MODULE(oce, pci, oce_driver, oce_devclass, 0, 0);
-MODULE_DEPEND(oce, pci, 1, 1, 1);
-MODULE_DEPEND(oce, ether, 1, 1, 1);
-MODULE_VERSION(oce, 1);
-
-
 /* global vars */
 const char component_revision[32] = {"///" COMPONENT_REVISION "///"};
 
@@ -241,6 +235,15 @@ static uint32_t supportedDevices[] =  {
 	(PCI_VENDOR_EMULEX << 16) | PCI_PRODUCT_XE201_VF,
 	(PCI_VENDOR_EMULEX << 16) | PCI_PRODUCT_SH
 };
+
+
+DRIVER_MODULE(oce, pci, oce_driver, oce_devclass, 0, 0);
+MODULE_PNP_INFO("W32:vendor/device", pci, oce, supportedDevices,
+    sizeof(supportedDevices[0]), nitems(supportedDevices));
+MODULE_DEPEND(oce, pci, 1, 1, 1);
+MODULE_DEPEND(oce, ether, 1, 1, 1);
+MODULE_VERSION(oce, 1);
+
 
 POCE_SOFTC softc_head = NULL;
 POCE_SOFTC softc_tail = NULL;

--- a/sys/dev/pci/pcivar.h
+++ b/sys/dev/pci/pcivar.h
@@ -301,6 +301,8 @@ struct pci_device_table {
 	.match_flag_subdevice = 1, .subdevice = (sd)
 #define PCI_DEVID(did)							\
 	PCI_DEV((uint16_t)did, (uint16_t)(did >> 16))
+#define PCI_VID(v)							\
+	.match_flag_vendor = 1, .vendor = (v)
 #define	PCI_CLASS(x)							\
 	.match_flag_class = 1, .class_id = (x)
 #define	PCI_SUBCLASS(x)							\

--- a/sys/dev/ppc/ppc_pci.c
+++ b/sys/dev/ppc/ppc_pci.c
@@ -83,35 +83,42 @@ struct pci_id {
 	int		rid;
 };
 
-static struct pci_id pci_ids[] = {
-	{ 0x1020131f, "SIIG Cyber Parallel PCI (10x family)", 0x18 },
-	{ 0x2020131f, "SIIG Cyber Parallel PCI (20x family)", 0x10 },
-	{ 0x05111407, "Lava SP BIDIR Parallel PCI", 0x10 },
-	{ 0x80001407, "Lava Computers 2SP-PCI parallel port", 0x10 },
-	{ 0x84031415, "Oxford Semiconductor OX12PCI840 Parallel port", 0x10 },
-	{ 0x95131415, "Oxford Semiconductor OX16PCI954 Parallel port", 0x10 },
-	{ 0xc1101415, "Oxford Semiconductor OXPCIe952 Parallel port", 0x10 },
-	{ 0x98059710, "NetMos NM9805 1284 Printer port", 0x10 },
-	{ 0x98659710, "MosChip MCS9865 1284 Printer port", 0x10 },
-	{ 0x99009710, "MosChip MCS9900 PCIe to Peripheral Controller", 0x10 },
-	{ 0x99019710, "MosChip MCS9901 PCIe to Peripheral Controller", 0x10 },
-	{ 0xffff }
+struct pci_device_table ppc_devs[] = {
+	{PCI_DEVID(0x1020131f), PCI_DESCR("SIIG Cyber Parallel PCI (10x family)"),
+	 .driver_data = 0x18},
+	{PCI_DEVID(0x2020131f), PCI_DESCR("SIIG Cyber Parallel PCI (20x family)"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x05111407), PCI_DESCR("Lava SP BIDIR Parallel PCI"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x80001407), PCI_DESCR("Lava Computers 2SP-PCI parallel port"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x84031415), PCI_DESCR("Oxford Semiconductor OX12PCI840 Parallel port"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x95131415), PCI_DESCR("Oxford Semiconductor OX16PCI954 Parallel port"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0xc1101415), PCI_DESCR("Oxford Semiconductor OXPCIe952 Parallel port"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x98059710), PCI_DESCR("NetMos NM9805 1284 Printer port"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x98659710), PCI_DESCR("MosChip MCS9865 1284 Printer port"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x99009710), PCI_DESCR("MosChip MCS9900 PCIe to Peripheral Controller"),
+	 .driver_data = 0x10},
+	{PCI_DEVID(0x99019710), PCI_DESCR("MosChip MCS9901 PCIe to Peripheral Controller"),
+	 .driver_data = 0x10},
 };
 
 static int
 ppc_pci_probe(device_t dev)
 {
-	struct pci_id *id;
-	uint32_t type;
+	const struct pci_device_table *ppcd;
 
-	type = pci_get_devid(dev);
-	id = pci_ids;
-	while (id->type != 0xffff && id->type != type)
-		id++;
-	if (id->type == 0xffff)
+	ppcd = PCI_MATCH(dev, ppc_devs)
+	if (ppcd == NULL)
 		return (ENXIO);
-	device_set_desc(dev, id->desc);
-	return (ppc_probe(dev, id->rid));
+	device_set_desc(dev, ppcd->descr);
+	return (ppc_probe(dev, ppcd->driver_data));
 }
 
 DRIVER_MODULE(ppc, pci, ppc_pci_driver, ppc_devclass, 0, 0);
+PCI_PNP_INFO(ppc_devs);

--- a/sys/dev/qlxgbe/ql_os.c
+++ b/sys/dev/qlxgbe/ql_os.c
@@ -104,6 +104,11 @@ static int qla_create_fp_taskqueues(qla_host_t *ha);
 static void qla_destroy_fp_taskqueues(qla_host_t *ha);
 static void qla_drain_fp_taskqueues(qla_host_t *ha);
 
+struct pci_device_table qla_pci_devs[] = {
+	{PCI_DEVID(PCI_QLOGIC_ISP8030),
+	 PCI_DESCR("Qlogic ISP 83xx PCI CNA Adapter-Ethernet Function")}
+};
+
 static device_method_t qla_pci_methods[] = {
 	/* Device interface */
 	DEVMETHOD(device_probe, qla_pci_probe),
@@ -119,6 +124,7 @@ static driver_t qla_pci_driver = {
 static devclass_t qla83xx_devclass;
 
 DRIVER_MODULE(qla83xx, pci, qla_pci_driver, qla83xx_devclass, 0, 0);
+PCI_PNP_INFO(qla_pci_devs);
 
 MODULE_DEPEND(qla83xx, pci, 1, 1, 1);
 MODULE_DEPEND(qla83xx, ether, 1, 1, 1);
@@ -139,25 +145,24 @@ static char ver_str[64];
 static int
 qla_pci_probe(device_t dev)
 {
-        switch ((pci_get_device(dev) << 16) | (pci_get_vendor(dev))) {
-        case PCI_QLOGIC_ISP8030:
-		snprintf(dev_str, sizeof(dev_str), "%s v%d.%d.%d",
-			"Qlogic ISP 83xx PCI CNA Adapter-Ethernet Function",
-			QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
-			QLA_VERSION_BUILD);
-		snprintf(ver_str, sizeof(ver_str), "v%d.%d.%d",
-			QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
-			QLA_VERSION_BUILD);
-                device_set_desc(dev, dev_str);
-                break;
-        default:
-                return (ENXIO);
-        }
+	const struct pci_device_table *qlad;
 
-        if (bootverbose)
-                printf("%s: %s\n ", __func__, dev_str);
+	qlad = PCI_MATCH(dev, qla_pci_devs);
+	if (qlad == NULL)
+		return (ENXIO);
+	snprintf(dev_str, sizeof(dev_str), "%s v%d.%d.%d",
+		 qlad->descr,
+		 QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
+		 QLA_VERSION_BUILD);
+	snprintf(ver_str, sizeof(ver_str), "v%d.%d.%d",
+		 QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
+		 QLA_VERSION_BUILD);
+	device_set_desc(dev, dev_str);
 
-        return (BUS_PROBE_DEFAULT);
+	if (bootverbose)
+		printf("%s: %s\n ", __func__, dev_str);
+
+	return (BUS_PROBE_DEFAULT);
 }
 
 static void

--- a/sys/dev/qlxge/qls_os.c
+++ b/sys/dev/qlxge/qls_os.c
@@ -97,6 +97,11 @@ static int qls_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data);
 static int qls_media_change(struct ifnet *ifp);
 static void qls_media_status(struct ifnet *ifp, struct ifmediareq *ifmr);
 
+struct pci_device_table qla_pci_devs[] = {
+	{PCI_DEVID(PCI_QLOGIC_DEV8000),
+	 PCI_DESCR("Qlogic ISP 8000 PCI CNA Adapter-Ethernet Function")}
+};
+
 static device_method_t qla_pci_methods[] = {
 	/* Device interface */
 	DEVMETHOD(device_probe, qls_pci_probe),
@@ -112,6 +117,7 @@ static driver_t qla_pci_driver = {
 static devclass_t qla8000_devclass;
 
 DRIVER_MODULE(qla8000, pci, qla_pci_driver, qla8000_devclass, 0, 0);
+PCI_PNP_INFO(qla_pci_devs);
 
 MODULE_DEPEND(qla8000, pci, 1, 1, 1);
 MODULE_DEPEND(qla8000, ether, 1, 1, 1);
@@ -128,20 +134,19 @@ static char ver_str[64];
 static int
 qls_pci_probe(device_t dev)
 {
-        switch ((pci_get_device(dev) << 16) | (pci_get_vendor(dev))) {
-        case PCI_QLOGIC_DEV8000:
-		snprintf(dev_str, sizeof(dev_str), "%s v%d.%d.%d",
-			"Qlogic ISP 8000 PCI CNA Adapter-Ethernet Function",
-			QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
-			QLA_VERSION_BUILD);
-		snprintf(ver_str, sizeof(ver_str), "v%d.%d.%d",
-			QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
-			QLA_VERSION_BUILD);
-                device_set_desc(dev, dev_str);
-                break;
-        default:
-                return (ENXIO);
-        }
+	const struct pci_device_table *qlsd;
+
+	qlsd = PCI_MATCH(dev, qla_pci_devs);
+	if (qlsd == NULL)
+		return (ENXIO);
+	snprintf(dev_str, sizeof(dev_str), "%s v%d.%d.%d",
+		 qlsd->descr,
+		 QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
+		 QLA_VERSION_BUILD);
+	snprintf(ver_str, sizeof(ver_str), "v%d.%d.%d",
+		 QLA_VERSION_MAJOR, QLA_VERSION_MINOR,
+		 QLA_VERSION_BUILD);
+	device_set_desc(dev, dev_str);
 
         if (bootverbose)
                 printf("%s: %s\n ", __func__, dev_str);

--- a/sys/dev/rp/rp_pci.c
+++ b/sys/dev/rp/rp_pci.c
@@ -123,6 +123,11 @@ static rp_aiop2rid_t rp_pci_aiop2rid;
 static rp_aiop2off_t rp_pci_aiop2off;
 static rp_ctlmask_t rp_pci_ctlmask;
 
+struct pci_device_table rp_devs[] = {
+	{PCI_VID(RP_VENDOR_ID),
+	 PCI_DESCR("RocketPort PCI")}
+};
+
 /*
  * The following functions are the pci-specific part
  * of rp driver.
@@ -131,18 +136,13 @@ static rp_ctlmask_t rp_pci_ctlmask;
 static int
 rp_pciprobe(device_t dev)
 {
-	char *s;
+	const struct pci_device_table *rpd;
 
-	s = NULL;
-	if (pci_get_vendor(dev) == RP_VENDOR_ID)
-		s = "RocketPort PCI";
-
-	if (s != NULL) {
-		device_set_desc(dev, s);
-		return (BUS_PROBE_DEFAULT);
-	}
-
-	return (ENXIO);
+	rpd = PCI_MATCH(dev, rp_devs);
+	if (rpd == NULL)
+		return (ENXIO);
+	device_set_desc(dev, rpd->descr);
+	return (BUS_PROBE_DEFAULT);
 }
 
 static int
@@ -365,3 +365,5 @@ static driver_t rp_pcidriver = {
  * rp can be attached to a pci bus.
  */
 DRIVER_MODULE(rp, pci, rp_pcidriver, rp_devclass, 0, 0);
+PCI_PNP_INFO(rp_devs);
+


### PR DESCRIPTION
Reviewed by: imp, chuck
Submitted by: Lakhan Shiva Kamireddy <lakhanshiva@gmail.com>
Sponsored by: Google, Inc. (GSoC 2018)
Pull Request: https://github.com/bsdimp/freebsd/pull/13
Url: https://reviews.freebsd.org/